### PR TITLE
add license title

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2014 Matt Jibson <matt.jibson@gmail.com>
 
 Permission to use, copy, modify, and distribute this software for any


### PR DESCRIPTION
It's not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license)